### PR TITLE
fix: ensure db directory exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import Database from "better-sqlite3";
-import { join } from "path";
+import { existsSync, mkdirSync } from "fs";
+import { dirname, join } from "path";
 import { homedir } from "os";
 
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
@@ -51,7 +52,14 @@ class PerplexityServer {
 
     // Initialize SQLite database
     const dbPath = join(homedir(), ".perplexity-mcp", "chat_history.db");
-    this.db = new Database(dbPath);
+
+    // Ensure the directory exists
+    const dbDir = dirname(dbPath);
+    if (!existsSync(dbDir)) {
+      mkdirSync(dbDir);
+    }
+
+    this.db = new Database(dbPath, { fileMustExist: false });
     this.initializeDatabase();
 
     this.setupToolHandlers();


### PR DESCRIPTION
# Fix Database Directory Creation

## Problem
The SQLite database initialization was failing when the `.perplexity-mcp` directory didn't exist in the user's home directory. This would cause the application to crash on first run for new users with the following error:

```
TypeError: Cannot open database because the directory does not exist
    at new Database (/Users/jacksteam/Documents/Cline/MCP/researcher-mcp/node_modules/better-sqlite3/lib/database.js:65:9)
    at new PerplexityServer (file:///Users/jacksteam/Documents/Cline/MCP/researcher-mcp/build/index.js:35:19)
    at file:///Users/jacksteam/Documents/Cline/MCP/researcher-mcp/build/index.js:314:16
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)
Node.js v20.16.0
MCP error -1: Connection closed
```

## Changes
- Import `existsSync` and `mkdirSync` from `fs` module
- Add directory existence check before database initialization
- Create the database directory if it doesn't exist
- Set `fileMustExist: false` in SQLite options to allow database file creation

## Testing
- Verified database initialization works when directory exists
- Verified directory and database are created automatically on first run
- Confirmed existing functionality works with created database

## Impact
This change improves the first-run experience for new users by automatically creating necessary directories and database files, preventing initialization errors.